### PR TITLE
fix: update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Every major coding agent now has rewind/undo: Claude Code (`/rewind`), Gemini CL
 pi install npm:pi-rewind
 
 # From GitHub
-pi install github.com/arpagon/pi-rewind
+pi install https://github.com/arpagon/pi-rewind
 
 # For development
 git clone git@github.com:arpagon/pi-rewind.git


### PR DESCRIPTION
For github install, it matches https|ssh|git, therefore without resorts to local.

```~/.pi
❯ pi install github.com/arpagon/pi-rewind
Installing github.com/arpagon/pi-rewind...
Error: Path does not exist: ...```